### PR TITLE
[Fix] streaming-data-types Conan depdendency

### DIFF
--- a/conanfile.txt
+++ b/conanfile.txt
@@ -11,7 +11,7 @@ h5cpp/0.4.1@ess-dmsc/stable
 logical-geometry/705ea61@ess-dmsc/stable
 qplot/6e192ab@ess-dmsc/stable
 Qt-Color-Widgets/9f4e052@ess-dmsc/stable
-streaming-data-types/f936e67@ess-dmsc/testing
+streaming-data-types/13dd32d@ess-dmsc/stable
 zlib/1.3
 
 [generators]


### PR DESCRIPTION
Fixes the `data-streaming-types` dependency problem #7 by updating to the [latest release `13dd32d`](https://github.com/ess-dmsc/conan-streaming-data-types)