### PR TITLE
ECDC-4181 Refactor plot update and add new histogram plot

### DIFF
--- a/conanfile.txt
+++ b/conanfile.txt
@@ -4,7 +4,7 @@ date/3.0.1
 eigen/3.3.9      #bump to 3.4.0 requires conan upgrade
 gtest/1.10.0
 fmt/6.2.0        #bump to 8.1.1 requires upgrade of spdlog as well
-librdkafka/2.0.2
+librdkafka/2.0.2#47048b3f05407bab726e359b27740c46
 nlohmann_json/3.10.5
 spdlog/1.8.5     #bump to 1.9.2 requires conan upgrade
 h5cpp/0.4.1@ess-dmsc/stable

--- a/configs/dream/dream_beam_monitor.json
+++ b/configs/dream/dream_beam_monitor.json
@@ -12,22 +12,21 @@
   },
 
   "geometry" : {
-    "xdim" : 1024,
-    "ydim" : 1024,
+    "xdim" : 10,
+    "ydim" : 10,
     "zdim" : 1,
     "offset" : 1
   },
 
   "tof" : {
     "scale" : 1000,
-    "max_value" : 71428,
-    "bin_size" : 512
+    "max_value" : 71428
   },
 
   "plot": {
-    "plot_type" : "tof",
-    "window_title" : "CBM TOF",
-    "plot_title" : "TOF",
+    "plot_type" : "histogram",
+    "window_title" : "CBM ADC TOF",
+    "plot_title" : "CBM ADC TOF",
     "clear_periodic" : false,
     "clear_interval_seconds" : 30,
     "interpolate_pixels" : false,

--- a/configs/dream/dream_beam_monitor.json
+++ b/configs/dream/dream_beam_monitor.json
@@ -2,7 +2,7 @@
   "kafka" : {
     "broker" : "10.70.6.62:9092",
     "topic" : "dream_beam_monitor",
-    "source": "cbm2",
+    "source": "cbm1",
 
     "message.max.bytes" : "10000000",
     "fetch.message.max.bytes" : "10000000",
@@ -12,10 +12,10 @@
   },
 
   "geometry" : {
-    "xdim" : 1,
-    "ydim" : 1,
+    "xdim" : 1024,
+    "ydim" : 1024,
     "zdim" : 1,
-    "offset" : 16777216
+    "offset" : 1
   },
 
   "tof" : {

--- a/scripts/dream.bash
+++ b/scripts/dream.bash
@@ -13,11 +13,11 @@ else
     DAQLITE_CONFIG="../configs"
 fi
 
-# $DAQLITE_HOME/bin/daqlite $BROKER -f $DAQLITE_CONFIG/dream/dream_tof.json $KAFKA_CONFIG &
-# $DAQLITE_HOME/bin/daqlite $BROKER -f $DAQLITE_CONFIG/dream/dream.json $KAFKA_CONFIG &
-# $DAQLITE_HOME/bin/daqlite $BROKER -f $DAQLITE_CONFIG/dream/dream_bwe.json $KAFKA_CONFIG &
-# $DAQLITE_HOME/bin/daqlite $BROKER -f $DAQLITE_CONFIG/dream/dream_fwe.json $KAFKA_CONFIG &
-# $DAQLITE_HOME/bin/daqlite $BROKER -f $DAQLITE_CONFIG/dream/dream_mantle.json $KAFKA_CONFIG &
-# $DAQLITE_HOME/bin/daqlite $BROKER -f $DAQLITE_CONFIG/dream/dream_hr.json $KAFKA_CONFIG &
-# $DAQLITE_HOME/bin/daqlite $BROKER -f $DAQLITE_CONFIG/dream/dream_sans.json $KAFKA_CONFIG &
+$DAQLITE_HOME/bin/daqlite $BROKER -f $DAQLITE_CONFIG/dream/dream_tof.json $KAFKA_CONFIG &
+$DAQLITE_HOME/bin/daqlite $BROKER -f $DAQLITE_CONFIG/dream/dream.json $KAFKA_CONFIG &
+$DAQLITE_HOME/bin/daqlite $BROKER -f $DAQLITE_CONFIG/dream/dream_bwe.json $KAFKA_CONFIG &
+$DAQLITE_HOME/bin/daqlite $BROKER -f $DAQLITE_CONFIG/dream/dream_fwe.json $KAFKA_CONFIG &
+$DAQLITE_HOME/bin/daqlite $BROKER -f $DAQLITE_CONFIG/dream/dream_mantle.json $KAFKA_CONFIG &
+$DAQLITE_HOME/bin/daqlite $BROKER -f $DAQLITE_CONFIG/dream/dream_hr.json $KAFKA_CONFIG &
+$DAQLITE_HOME/bin/daqlite $BROKER -f $DAQLITE_CONFIG/dream/dream_sans.json $KAFKA_CONFIG &
 $DAQLITE_HOME/bin/daqlite $BROKER -f $DAQLITE_CONFIG/dream/dream_beam_monitor.json $KAFKA_CONFIG &

--- a/scripts/dream.bash
+++ b/scripts/dream.bash
@@ -13,11 +13,11 @@ else
     DAQLITE_CONFIG="../configs"
 fi
 
-$DAQLITE_HOME/bin/daqlite $BROKER -f $DAQLITE_CONFIG/dream/dream_tof.json $KAFKA_CONFIG &
-$DAQLITE_HOME/bin/daqlite $BROKER -f $DAQLITE_CONFIG/dream/dream.json $KAFKA_CONFIG &
-$DAQLITE_HOME/bin/daqlite $BROKER -f $DAQLITE_CONFIG/dream/dream_bwe.json $KAFKA_CONFIG &
-$DAQLITE_HOME/bin/daqlite $BROKER -f $DAQLITE_CONFIG/dream/dream_fwe.json $KAFKA_CONFIG &
-$DAQLITE_HOME/bin/daqlite $BROKER -f $DAQLITE_CONFIG/dream/dream_mantle.json $KAFKA_CONFIG &
-$DAQLITE_HOME/bin/daqlite $BROKER -f $DAQLITE_CONFIG/dream/dream_hr.json $KAFKA_CONFIG &
-$DAQLITE_HOME/bin/daqlite $BROKER -f $DAQLITE_CONFIG/dream/dream_sans.json $KAFKA_CONFIG &
+# $DAQLITE_HOME/bin/daqlite $BROKER -f $DAQLITE_CONFIG/dream/dream_tof.json $KAFKA_CONFIG &
+# $DAQLITE_HOME/bin/daqlite $BROKER -f $DAQLITE_CONFIG/dream/dream.json $KAFKA_CONFIG &
+# $DAQLITE_HOME/bin/daqlite $BROKER -f $DAQLITE_CONFIG/dream/dream_bwe.json $KAFKA_CONFIG &
+# $DAQLITE_HOME/bin/daqlite $BROKER -f $DAQLITE_CONFIG/dream/dream_fwe.json $KAFKA_CONFIG &
+# $DAQLITE_HOME/bin/daqlite $BROKER -f $DAQLITE_CONFIG/dream/dream_mantle.json $KAFKA_CONFIG &
+# $DAQLITE_HOME/bin/daqlite $BROKER -f $DAQLITE_CONFIG/dream/dream_hr.json $KAFKA_CONFIG &
+# $DAQLITE_HOME/bin/daqlite $BROKER -f $DAQLITE_CONFIG/dream/dream_sans.json $KAFKA_CONFIG &
 $DAQLITE_HOME/bin/daqlite $BROKER -f $DAQLITE_CONFIG/dream/dream_beam_monitor.json $KAFKA_CONFIG &

--- a/src/daqlite/AbstractPlot.h
+++ b/src/daqlite/AbstractPlot.h
@@ -1,0 +1,44 @@
+// Copyright (C) 2024 European Spallation Source, ERIC. See LICENSE file
+//===----------------------------------------------------------------------===//
+///
+/// \file AbstractPlot.h
+///
+/// \brief 
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "ESSConsumer.h"
+#include <QPlot/QPlot.h>
+
+enum PlotType {
+    TOF2D,
+    TOF,
+    PIXEL,
+    HISTOGRAM
+};
+
+class AbstractPlot : public QCustomPlot {
+    Q_OBJECT
+
+    PlotType mPlotType;
+
+protected:
+    ESSConsumer *mConsumer{nullptr};
+
+
+public:
+    void registerConsumer(ESSConsumer &Consumer) {
+        mConsumer = &Consumer;
+    }
+
+    virtual void clearDetectorImage() = 0;
+
+    virtual void updateData() = 0;
+
+    virtual void plotDetectorImage(bool Force) = 0;
+
+    PlotType getPlotType() {
+        return mPlotType;
+    }
+};

--- a/src/daqlite/AbstractPlot.h
+++ b/src/daqlite/AbstractPlot.h
@@ -3,7 +3,7 @@
 ///
 /// \file AbstractPlot.h
 ///
-/// \brief 
+/// \brief
 //===----------------------------------------------------------------------===//
 
 #pragma once
@@ -11,34 +11,25 @@
 #include "ESSConsumer.h"
 #include <QPlot/QPlot.h>
 
-enum PlotType {
-    TOF2D,
-    TOF,
-    PIXEL,
-    HISTOGRAM
-};
+enum PlotType { TOF2D, TOF, PIXEL, HISTOGRAM };
 
 class AbstractPlot : public QCustomPlot {
-    Q_OBJECT
+  Q_OBJECT
 
-    PlotType mPlotType;
+  PlotType mPlotType;
 
 protected:
-    ESSConsumer *mConsumer{nullptr};
+  AbstractPlot(PlotType Type, ESSConsumer &Consumer)
+      : mPlotType(Type), mConsumer(Consumer) {}
 
+  ESSConsumer &mConsumer;
 
 public:
-    void registerConsumer(ESSConsumer &Consumer) {
-        mConsumer = &Consumer;
-    }
+  virtual void clearDetectorImage() = 0;
 
-    virtual void clearDetectorImage() = 0;
+  virtual void updateData() = 0;
 
-    virtual void updateData() = 0;
+  virtual void plotDetectorImage(bool Force) = 0;
 
-    virtual void plotDetectorImage(bool Force) = 0;
-
-    PlotType getPlotType() {
-        return mPlotType;
-    }
+  PlotType getPlotType() { return mPlotType; }
 };

--- a/src/daqlite/CMakeLists.txt
+++ b/src/daqlite/CMakeLists.txt
@@ -8,6 +8,7 @@ set(daqlite_src
   Custom2DPlot.cpp
   CustomAMOR2DTOFPlot.cpp
   CustomTofPlot.cpp
+  HistogramPlot.cpp
   ESSConsumer.cpp
   KafkaConfig.cpp
   MainWindow.cpp
@@ -19,10 +20,13 @@ set(daqlite_inc
   Custom2DPlot.h
   CustomAMOR2DTOFPlot.h
   CustomTofPlot.h
+  HistogramPlot.h
+  AbstractPlot.h
   ESSConsumer.h
   KafkaConfig.h
   MainWindow.h
   WorkerThread.h
+  ThreadSafeVector.h
   )
 
 set(daqlite_ui

--- a/src/daqlite/Custom2DPlot.cpp
+++ b/src/daqlite/Custom2DPlot.cpp
@@ -193,8 +193,7 @@ void Custom2DPlot::updateData() {
   std::chrono::duration<int64_t, std::nano> elapsed = t2 - t1;
 
   // update histogram data from consumer of worker thread
-  std::vector<uint32_t> Histogram = mConsumer.mHistogram;
-  mConsumer.mPixelIDs.fill(0);
+  std::vector<uint32_t> Histogram = mConsumer.readOutHistogram();
 
   int64_t nsBetweenClear = 1000000000LL * mConfig.Plot.ClearEverySeconds;
   if (mConfig.Plot.ClearPeriodic and (elapsed.count() >= nsBetweenClear)) {

--- a/src/daqlite/Custom2DPlot.cpp
+++ b/src/daqlite/Custom2DPlot.cpp
@@ -193,7 +193,7 @@ void Custom2DPlot::updateData() {
   std::chrono::duration<int64_t, std::nano> elapsed = t2 - t1;
 
   // update histogram data from consumer of worker thread
-  std::vector<uint32_t> Histogram = mConsumer.readOutHistogram();
+  std::vector<uint32_t> Histogram = mConsumer.readResetHistogram();
 
   int64_t nsBetweenClear = 1000000000LL * mConfig.Plot.ClearEverySeconds;
   if (mConfig.Plot.ClearPeriodic and (elapsed.count() >= nsBetweenClear)) {

--- a/src/daqlite/Custom2DPlot.cpp
+++ b/src/daqlite/Custom2DPlot.cpp
@@ -5,8 +5,6 @@
 ///
 //===----------------------------------------------------------------------===//
 
-#include "AbstractPlot.h"
-#include "ESSConsumer.h"
 #include <Custom2DPlot.h>
 #include <WorkerThread.h>
 #include <algorithm>

--- a/src/daqlite/Custom2DPlot.cpp
+++ b/src/daqlite/Custom2DPlot.cpp
@@ -5,6 +5,8 @@
 ///
 //===----------------------------------------------------------------------===//
 
+#include "AbstractPlot.h"
+#include "ESSConsumer.h"
 #include <Custom2DPlot.h>
 #include <WorkerThread.h>
 #include <algorithm>
@@ -12,8 +14,9 @@
 #include <fmt/format.h>
 #include <string>
 
-Custom2DPlot::Custom2DPlot(Configuration &Config, Projection Proj)
-    : mConfig(Config), mProjection(Proj) {
+Custom2DPlot::Custom2DPlot(Configuration &Config, ESSConsumer &Consumer,
+                           Projection Proj)
+    : AbstractPlot(PIXEL, Consumer), mConfig(Config), mProjection(Proj) {
 
   // Register callback functions for events
   connect(this, SIGNAL(mouseMove(QMouseEvent *)), this,
@@ -190,15 +193,15 @@ void Custom2DPlot::updateData() {
   std::chrono::duration<int64_t, std::nano> elapsed = t2 - t1;
 
   // update histogram data from consumer of worker thread
-  std::vector<uint32_t> Histogram = mConsumer->mHistogram;
-  mConsumer->mPixelIDs.fill(0);
+  std::vector<uint32_t> Histogram = mConsumer.mHistogram;
+  mConsumer.mPixelIDs.fill(0);
 
   int64_t nsBetweenClear = 1000000000LL * mConfig.Plot.ClearEverySeconds;
   if (mConfig.Plot.ClearPeriodic and (elapsed.count() >= nsBetweenClear)) {
     t1 = std::chrono::high_resolution_clock::now();
     std::fill(HistogramData.begin(), HistogramData.end(), 0);
-    plotDetectorImage(true);// Periodically clear the histogram
-  //
+    plotDetectorImage(true); // Periodically clear the histogram
+    //
   }
 
   // Accumulate counts, PixelId 0 does not exist

--- a/src/daqlite/Custom2DPlot.cpp
+++ b/src/daqlite/Custom2DPlot.cpp
@@ -144,7 +144,6 @@ std::string Custom2DPlot::getNextColorGradient(std::string GradientName) {
 
 void Custom2DPlot::clearDetectorImage() {
   std::fill(HistogramData.begin(), HistogramData.end(), 0);
-  addData(HistogramData);
   plotDetectorImage(true);
 }
 
@@ -160,7 +159,7 @@ void Custom2DPlot::plotDetectorImage(bool Force) {
       auto yIndex = LogicalGeometry->y(i);
       auto zIndex = LogicalGeometry->z(i);
 
-      // here we could 
+      // here we could
       // x, y, z = pos(i)
 
       if (mProjection == ProjectionXY) {
@@ -186,17 +185,20 @@ void Custom2DPlot::plotDetectorImage(bool Force) {
   replot();
 }
 
-void Custom2DPlot::addData(std::vector<uint32_t> &Histogram) {
+void Custom2DPlot::updateData() {
   auto t2 = std::chrono::high_resolution_clock::now();
   std::chrono::duration<int64_t, std::nano> elapsed = t2 - t1;
 
-  // Periodically clear the histogram
-  //
+  // update histogram data from consumer of worker thread
+  std::vector<uint32_t> Histogram = mConsumer->mHistogram;
+  mConsumer->mPixelIDs.fill(0);
+
   int64_t nsBetweenClear = 1000000000LL * mConfig.Plot.ClearEverySeconds;
   if (mConfig.Plot.ClearPeriodic and (elapsed.count() >= nsBetweenClear)) {
     t1 = std::chrono::high_resolution_clock::now();
     std::fill(HistogramData.begin(), HistogramData.end(), 0);
-    plotDetectorImage(true);
+    plotDetectorImage(true);// Periodically clear the histogram
+  //
   }
 
   // Accumulate counts, PixelId 0 does not exist

--- a/src/daqlite/Custom2DPlot.h
+++ b/src/daqlite/Custom2DPlot.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "AbstractPlot.h"
+#include "ESSConsumer.h"
 #include <Configuration.h>
 #include <QPlot/QPlot.h>
 #include <chrono>
@@ -20,7 +21,7 @@ public:
   enum Projection {ProjectionXY, ProjectionXZ, ProjectionYZ};
 
   /// \brief plot needs the configurable plotting options
-  Custom2DPlot(Configuration &Config, Projection Proj);
+  Custom2DPlot(Configuration &Config, ESSConsumer&, Projection Proj);
 
   /// \brief adds histogram data, clears periodically then calls
   /// plotDetectorImage()

--- a/src/daqlite/Custom2DPlot.h
+++ b/src/daqlite/Custom2DPlot.h
@@ -8,12 +8,13 @@
 
 #pragma once
 
+#include "AbstractPlot.h"
 #include <Configuration.h>
 #include <QPlot/QPlot.h>
 #include <chrono>
 #include <logical_geometry/ESSGeometry.h>
 
-class Custom2DPlot : public QCustomPlot {
+class Custom2DPlot : public AbstractPlot {
   Q_OBJECT
 public:
   enum Projection {ProjectionXY, ProjectionXZ, ProjectionYZ};
@@ -23,7 +24,7 @@ public:
 
   /// \brief adds histogram data, clears periodically then calls
   /// plotDetectorImage()
-  void addData(std::vector<uint32_t> &Histogram);
+  void updateData() override;
 
   /// \brief Support for different gradients
   QCPColorGradient getColorGradient(std::string GradientName);
@@ -35,11 +36,11 @@ public:
   std::string getNextColorGradient(std::string GradientName);
 
   /// \brief clears histogram data
-  void clearDetectorImage();
+  void clearDetectorImage() override;
 
   /// \brief updates the image
   /// \param Force forces updates of histogram data with zero count
-  void plotDetectorImage(bool Force);
+  void plotDetectorImage(bool Force) override;
 
 public slots:
   void showPointToolTip(QMouseEvent *event);

--- a/src/daqlite/Custom2DPlot.h
+++ b/src/daqlite/Custom2DPlot.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 - 2021 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2020 - 2024 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file Custom2DPlot.h
@@ -8,8 +8,8 @@
 
 #pragma once
 
-#include "AbstractPlot.h"
-#include "ESSConsumer.h"
+#include <AbstractPlot.h>
+#include <ESSConsumer.h>
 #include <Configuration.h>
 #include <QPlot/QPlot.h>
 #include <chrono>

--- a/src/daqlite/CustomAMOR2DTOFPlot.cpp
+++ b/src/daqlite/CustomAMOR2DTOFPlot.cpp
@@ -170,11 +170,8 @@ void CustomAMOR2DTOFPlot::updateData() {
   std::chrono::duration<int64_t, std::nano> elapsed = t2 - t1;
 
   // Get newest histogram data from Consumer
-  std::vector<uint32_t> PixelIDs = mConsumer.mPixelIDs;
-  std::vector<uint32_t> TOFs = mConsumer.mTOFs;
-
-  mConsumer.mPixelIDs.clear();
-  mConsumer.mTOFs.clear();
+  std::vector<uint32_t> PixelIDs = mConsumer.readOutPixelIDs();
+  std::vector<uint32_t> TOFs = mConsumer.readOutTOFs();
 
   // Accumulate counts, PixelId 0 does not exist
   if (PixelIDs.size() == 0) {

--- a/src/daqlite/CustomAMOR2DTOFPlot.cpp
+++ b/src/daqlite/CustomAMOR2DTOFPlot.cpp
@@ -5,8 +5,6 @@
 ///
 //===----------------------------------------------------------------------===//
 
-#include "AbstractPlot.h"
-#include "ESSConsumer.h"
 #include <CustomAMOR2DTOFPlot.h>
 #include <WorkerThread.h>
 #include <algorithm>

--- a/src/daqlite/CustomAMOR2DTOFPlot.cpp
+++ b/src/daqlite/CustomAMOR2DTOFPlot.cpp
@@ -148,7 +148,7 @@ void CustomAMOR2DTOFPlot::clearDetectorImage() {
 void CustomAMOR2DTOFPlot::plotDetectorImage(bool Force) {
   setCustomParameters();
 
-  for (unsigned int y = 0; y < mConfig.Geometry.YDim; y++) {
+  for (int y = 0; y < mConfig.Geometry.YDim; y++) {
     for (unsigned int x = 0; x < mConfig.TOF.BinSize; x++) {
       if ((HistogramData2D[x][y] == 0) and (not Force)) {
         continue;
@@ -166,12 +166,9 @@ void CustomAMOR2DTOFPlot::plotDetectorImage(bool Force) {
 }
 
 void CustomAMOR2DTOFPlot::updateData() {
-  auto t2 = std::chrono::high_resolution_clock::now();
-  std::chrono::duration<int64_t, std::nano> elapsed = t2 - t1;
-
   // Get newest histogram data from Consumer
-  std::vector<uint32_t> PixelIDs = mConsumer.readOutPixelIDs();
-  std::vector<uint32_t> TOFs = mConsumer.readOutTOFs();
+  std::vector<uint32_t> PixelIDs = mConsumer.readResetPixelIDs();
+  std::vector<uint32_t> TOFs = mConsumer.readResetTOFs();
 
   // Accumulate counts, PixelId 0 does not exist
   if (PixelIDs.size() == 0) {

--- a/src/daqlite/CustomAMOR2DTOFPlot.cpp
+++ b/src/daqlite/CustomAMOR2DTOFPlot.cpp
@@ -5,6 +5,8 @@
 ///
 //===----------------------------------------------------------------------===//
 
+#include "AbstractPlot.h"
+#include "ESSConsumer.h"
 #include <CustomAMOR2DTOFPlot.h>
 #include <WorkerThread.h>
 #include <algorithm>
@@ -12,8 +14,9 @@
 #include <fmt/format.h>
 #include <string>
 
-CustomAMOR2DTOFPlot::CustomAMOR2DTOFPlot(Configuration &Config)
-    : mConfig(Config) {
+CustomAMOR2DTOFPlot::CustomAMOR2DTOFPlot(Configuration &Config,
+                                         ESSConsumer &Consumer)
+    : AbstractPlot(TOF2D, Consumer), mConfig(Config) {
 
   if ((not(mConfig.Geometry.YDim <= TOF2DY) or
        (not(mConfig.TOF.BinSize <= TOF2DX)))) {
@@ -167,11 +170,11 @@ void CustomAMOR2DTOFPlot::updateData() {
   std::chrono::duration<int64_t, std::nano> elapsed = t2 - t1;
 
   // Get newest histogram data from Consumer
-  std::vector<uint32_t> PixelIDs = mConsumer->mPixelIDs;
-  std::vector<uint32_t> TOFs = mConsumer->mTOFs;
+  std::vector<uint32_t> PixelIDs = mConsumer.mPixelIDs;
+  std::vector<uint32_t> TOFs = mConsumer.mTOFs;
 
-  mConsumer->mPixelIDs.clear();
-  mConsumer->mTOFs.clear();
+  mConsumer.mPixelIDs.clear();
+  mConsumer.mTOFs.clear();
 
   // Accumulate counts, PixelId 0 does not exist
   if (PixelIDs.size() == 0) {

--- a/src/daqlite/CustomAMOR2DTOFPlot.h
+++ b/src/daqlite/CustomAMOR2DTOFPlot.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "AbstractPlot.h"
+#include "ESSConsumer.h"
 #include <Configuration.h>
 #include <QPlot/QPlot.h>
 #include <chrono>
@@ -18,7 +19,7 @@ class CustomAMOR2DTOFPlot : public AbstractPlot {
   Q_OBJECT
 public:
   /// \brief plot needs the configurable plotting options
-  CustomAMOR2DTOFPlot(Configuration &Config);
+  CustomAMOR2DTOFPlot(Configuration &Config, ESSConsumer &Consumer);
 
   /// \brief adds histogram data, clears periodically then calls
   /// plotDetectorImage()

--- a/src/daqlite/CustomAMOR2DTOFPlot.h
+++ b/src/daqlite/CustomAMOR2DTOFPlot.h
@@ -8,12 +8,13 @@
 
 #pragma once
 
+#include "AbstractPlot.h"
 #include <Configuration.h>
 #include <QPlot/QPlot.h>
 #include <chrono>
 #include <logical_geometry/ESSGeometry.h>
 
-class CustomAMOR2DTOFPlot : public QCustomPlot {
+class CustomAMOR2DTOFPlot : public AbstractPlot {
   Q_OBJECT
 public:
   /// \brief plot needs the configurable plotting options
@@ -21,7 +22,7 @@ public:
 
   /// \brief adds histogram data, clears periodically then calls
   /// plotDetectorImage()
-  void addData(std::vector<uint32_t> &Pixels, std::vector<uint32_t> &TOFs);
+  void updateData() override;
 
   /// \brief Support for different gradients
   QCPColorGradient getColorGradient(std::string GradientName);
@@ -32,13 +33,12 @@ public:
   /// \brief rotate through gradient names
   std::string getNextColorGradient(std::string GradientName);
 
-  /// \brief clears histogram data
-  void clearDetectorImage(std::vector<uint32_t> &PixelIDs,
-      std::vector<uint32_t> &TOFs);
+  /// \brief clears histogram data (overridden from AbstractPlot)
+  void clearDetectorImage() override;
 
   /// \brief updates the image
   /// \param Force forces updates of histogram data with zero count
-  void plotDetectorImage(bool Force);
+  void plotDetectorImage(bool Force) override;
 
 public slots:
   void showPointToolTip(QMouseEvent *event);

--- a/src/daqlite/CustomAMOR2DTOFPlot.h
+++ b/src/daqlite/CustomAMOR2DTOFPlot.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2022-2024 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file CustomAMOR2DTOFPlot.h
@@ -8,8 +8,8 @@
 
 #pragma once
 
-#include "AbstractPlot.h"
-#include "ESSConsumer.h"
+#include <AbstractPlot.h>
+#include <ESSConsumer.h>
 #include <Configuration.h>
 #include <QPlot/QPlot.h>
 #include <chrono>

--- a/src/daqlite/CustomTofPlot.cpp
+++ b/src/daqlite/CustomTofPlot.cpp
@@ -101,7 +101,7 @@ void CustomTofPlot::updateData() {
   std::chrono::duration<int64_t, std::nano> elapsed = t2 - t1;
 
   // Get histogram data from Consumer and clear it
-  std::vector<uint32_t> Histogram = mConsumer.readOutHistogram();
+  std::vector<uint32_t> Histogram = mConsumer.readResetHistogram();
 
   // Periodically clear the histogram
   int64_t nsBetweenClear = 1000000000LL * mConfig.Plot.ClearEverySeconds;

--- a/src/daqlite/CustomTofPlot.cpp
+++ b/src/daqlite/CustomTofPlot.cpp
@@ -5,8 +5,6 @@
 ///
 //===----------------------------------------------------------------------===//
 
-#include "AbstractPlot.h"
-#include "ESSConsumer.h"
 #include <CustomTofPlot.h>
 #include <QPlot/qcustomplot/qcustomplot.h>
 #include <WorkerThread.h>

--- a/src/daqlite/CustomTofPlot.cpp
+++ b/src/daqlite/CustomTofPlot.cpp
@@ -101,8 +101,7 @@ void CustomTofPlot::updateData() {
   std::chrono::duration<int64_t, std::nano> elapsed = t2 - t1;
 
   // Get histogram data from Consumer and clear it
-  std::vector<uint32_t> Histogram = mConsumer.mHistogramTof;
-  mConsumer.mHistogramTof.fill(0);
+  std::vector<uint32_t> Histogram = mConsumer.readOutHistogram();
 
   // Periodically clear the histogram
   int64_t nsBetweenClear = 1000000000LL * mConfig.Plot.ClearEverySeconds;

--- a/src/daqlite/CustomTofPlot.cpp
+++ b/src/daqlite/CustomTofPlot.cpp
@@ -5,6 +5,8 @@
 ///
 //===----------------------------------------------------------------------===//
 
+#include "AbstractPlot.h"
+#include "ESSConsumer.h"
 #include <CustomTofPlot.h>
 #include <QPlot/qcustomplot/qcustomplot.h>
 #include <WorkerThread.h>
@@ -13,7 +15,8 @@
 #include <fmt/format.h>
 #include <string>
 
-CustomTofPlot::CustomTofPlot(Configuration &Config) : mConfig(Config) {
+CustomTofPlot::CustomTofPlot(Configuration &Config, ESSConsumer &Consumer)
+    : AbstractPlot(TOF, Consumer), mConfig(Config) {
 
   // Register callback functions for events
   connect(this, SIGNAL(mouseMove(QMouseEvent *)), this,
@@ -41,7 +44,7 @@ CustomTofPlot::CustomTofPlot(Configuration &Config) : mConfig(Config) {
   // mGraph->setLineStyle(QCPGraph::lsNone);
   mGraph->setBrush(QBrush(QColor(0, 0, 255, 20)));
   mGraph->setLineStyle(QCPGraph::lsStepCenter);
-  mGraph->  setScatterStyle(QCPScatterStyle(QCPScatterStyle::ssCircle, 5));
+  mGraph->setScatterStyle(QCPScatterStyle(QCPScatterStyle::ssCircle, 5));
 
   // we want the color map to have nx * ny data points
 
@@ -86,7 +89,7 @@ void CustomTofPlot::plotDetectorImage(bool Force) {
   if (mConfig.TOF.AutoScaleX) {
     xAxis->setRange(0, mConfig.TOF.MaxValue * 1.05);
   }
-  if (mConfig.TOF.AutoScaleY){
+  if (mConfig.TOF.AutoScaleY) {
     yAxis->setRange(0, MaxY * 1.05);
   }
   replot();
@@ -98,8 +101,8 @@ void CustomTofPlot::updateData() {
   std::chrono::duration<int64_t, std::nano> elapsed = t2 - t1;
 
   // Get histogram data from Consumer and clear it
-  std::vector<uint32_t> Histogram = mConsumer->mHistogramTof;
-  mConsumer->mHistogramTof.fill(0);
+  std::vector<uint32_t> Histogram = mConsumer.mHistogramTof;
+  mConsumer.mHistogramTof.fill(0);
 
   // Periodically clear the histogram
   int64_t nsBetweenClear = 1000000000LL * mConfig.Plot.ClearEverySeconds;

--- a/src/daqlite/CustomTofPlot.h
+++ b/src/daqlite/CustomTofPlot.h
@@ -19,7 +19,7 @@ class CustomTofPlot : public AbstractPlot {
 public:
 
   /// \brief plot needs the configurable plotting options
-  CustomTofPlot(Configuration &Config);
+  CustomTofPlot(Configuration &Config, ESSConsumer &Consumer);
 
   /// \brief adds histogram data, clears periodically then calls
   /// plotDetectorImage()

--- a/src/daqlite/CustomTofPlot.h
+++ b/src/daqlite/CustomTofPlot.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 - 2021 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2020 - 2024 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file CustomTofPlot.h
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include "AbstractPlot.h"
+#include <AbstractPlot.h>
 #include <Configuration.h>
 #include <QPlot/QPlot.h>
 #include <chrono>

--- a/src/daqlite/ESSConsumer.cpp
+++ b/src/daqlite/ESSConsumer.cpp
@@ -5,13 +5,13 @@
 ///
 //===----------------------------------------------------------------------===//
 
-#include <da00_dataarray_generated.h>
-#include <ev42_events_generated.h>
-#include <ev44_events_generated.h>
 #include <ESSConsumer.h>
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
+#include <da00_dataarray_generated.h>
+#include <ev42_events_generated.h>
+#include <ev44_events_generated.h>
 #include <fmt/core.h>
 #include <fmt/format.h>
 #include <iostream>
@@ -150,6 +150,7 @@ uint32_t ESSConsumer::processDA00Data(RdKafka::Message *Msg) {
     return 0;
   }
 
+  // convert vectors to uint32_t
   std::vector<uint32_t> TimeBinsUInt32(TimeBins.size());
   std::transform(TimeBins.begin(), TimeBins.end(), TimeBinsUInt32.begin(),
                  [](int64_t val) { return static_cast<uint32_t>(val); });
@@ -160,6 +161,8 @@ uint32_t ESSConsumer::processDA00Data(RdKafka::Message *Msg) {
 
   mHistogram.add_values(DataBinsUInt32);
   mTOFs = TimeBinsUInt32;
+
+  mConfig.TOF.BinSize = TimeBins.size();
 
   EventCount++;
   EventAccept++;

--- a/src/daqlite/ESSConsumer.cpp
+++ b/src/daqlite/ESSConsumer.cpp
@@ -5,11 +5,9 @@
 ///
 //===----------------------------------------------------------------------===//
 
-#include "Configuration.h"
-#include "da00_dataarray_generated.h"
-#include "ev42_events_generated.h"
-#include "ev44_events_generated.h"
-#include "flatbuffers/flatbuffers.h"
+#include <da00_dataarray_generated.h>
+#include <ev42_events_generated.h>
+#include <ev44_events_generated.h>
 #include <ESSConsumer.h>
 #include <algorithm>
 #include <cstddef>

--- a/src/daqlite/ESSConsumer.cpp
+++ b/src/daqlite/ESSConsumer.cpp
@@ -152,7 +152,8 @@ uint32_t ESSConsumer::processDA00Data(RdKafka::Message *Msg) {
     return 0;
   }
 
-  std::vector<uint32_t> CountBinValuesVector(mHistogramTof.size(), 0);
+  std::vector<uint32_t> CountBinValueVector;
+  std::vector<uint32_t> BinTofValueVector;
 
   for (size_t i = 0; i < TimeBins.size(); i++) {
     int64_t TimeBin = TimeBins[i];
@@ -166,13 +167,12 @@ uint32_t ESSConsumer::processDA00Data(RdKafka::Message *Msg) {
       continue;
     }
 
-    int index = TimeBin / ((mConfig.TOF.MaxValue * mConfig.TOF.Scale) /
-                           (mConfig.TOF.BinSize - 1));
-
-    CountBinValuesVector[index] += DataBin;
+    CountBinValueVector[i] += DataBin;
+    BinTofValueVector[i] = TimeBin;
   }
 
-  mHistogramTof.add_values(CountBinValuesVector);
+  mHistogram.add_values(CountBinValueVector);
+  mTOFs = BinTofValueVector;
 
   EventCount++;
   EventAccept++;

--- a/src/daqlite/ESSConsumer.cpp
+++ b/src/daqlite/ESSConsumer.cpp
@@ -150,17 +150,8 @@ uint32_t ESSConsumer::processDA00Data(RdKafka::Message *Msg) {
     return 0;
   }
 
-  // convert vectors to uint32_t
-  std::vector<uint32_t> TimeBinsUInt32(TimeBins.size());
-  std::transform(TimeBins.begin(), TimeBins.end(), TimeBinsUInt32.begin(),
-                 [](int64_t val) { return static_cast<uint32_t>(val); });
-
-  std::vector<uint32_t> DataBinsUInt32(DataBins.size());
-  std::transform(DataBins.begin(), DataBins.end(), DataBinsUInt32.begin(),
-                 [](int64_t val) { return static_cast<uint32_t>(val); });
-
-  mHistogram.add_values(DataBinsUInt32);
-  mTOFs = TimeBinsUInt32;
+  mHistogram.add_values(DataBins);
+  mTOFs = TimeBins;
 
   mConfig.TOF.BinSize = TimeBins.size();
 

--- a/src/daqlite/ESSConsumer.h
+++ b/src/daqlite/ESSConsumer.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 - 2022 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2020 - 2024 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file ESSConsumer.h
@@ -10,9 +10,9 @@
 
 #pragma once
 
-#include "ThreadSafeVector.h"
-#include "da00_dataarray_generated.h"
-#include "flatbuffers/flatbuffers.h"
+#include <ThreadSafeVector.h>
+#include <da00_dataarray_generated.h>
+#include <flatbuffers/flatbuffers.h>
 #include <Configuration.h>
 #include <cstdint>
 #include <librdkafka/rdkafkacpp.h>

--- a/src/daqlite/ESSConsumer.h
+++ b/src/daqlite/ESSConsumer.h
@@ -14,10 +14,42 @@
 #include "da00_dataarray_generated.h"
 #include "flatbuffers/flatbuffers.h"
 #include <Configuration.h>
+#include <cstdint>
 #include <librdkafka/rdkafkacpp.h>
 #include <mutex>
 #include <string>
 
+/// \class ESSConsumer
+/// \brief A class to handle Kafka consumer operations for ESS data.
+///
+/// The ESSConsumer class is responsible for consuming messages from a Kafka
+/// broker, processing the messages, and managing histograms and other data
+/// structures related to the consumed messages.
+///
+/// \details
+/// This class provides methods to configure and subscribe to Kafka topics,
+/// consume messages, handle errors, and process specific types of data
+/// messages. It also includes methods to read out and reset histograms and
+/// other data structures.
+///
+/// \note
+/// The class uses librdkafka for Kafka operations and includes thread-safe
+/// data structures for histogram storage.
+///
+/// \example
+/// \code
+/// Configuration config;
+/// std::vector<std::pair<std::string, std::string>> kafkaConfig;
+/// ESSConsumer consumer(config, kafkaConfig);
+/// auto message = consumer.consume();
+/// if (consumer.handleMessage(message.get())) {
+///     // Process the message
+/// }
+/// \endcode
+///
+/// \see Configuration
+/// \see RdKafka::Message
+/// \see RdKafka::KafkaConsumer
 class ESSConsumer {
 public:
   /// \brief Constructor needs the configured Broker and Topic
@@ -34,6 +66,56 @@ public:
   /// \return true if message contains data, false otherwise
   bool handleMessage(RdKafka::Message *message);
 
+  /// \brief return a random group id so that simultaneous consume from
+  /// multiple applications is possible.
+  static std::string randomGroupString(size_t length);
+
+  uint64_t EventCount{0};
+  uint64_t EventAccept{0};
+  uint64_t EventDiscard{0};
+
+  /// \brief read out the histogram data and reset it
+  std::vector<uint32_t> readOutHistogram() {
+    return mHistogram;
+    mHistogram.fill(0);
+  }
+
+  /// \brief read out the TOF histogram data and reset it
+  std::vector<uint32_t> readOutHistogramTof() {
+    return mHistogramTof;
+    mHistogramTof.fill(0);
+  }
+
+  /// \brief read out the event pixel IDs and clear the vector
+  std::vector<uint32_t> readOutPixelIDs() {
+    return mPixelIDs;
+    mPixelIDs.clear();
+  }
+
+  /// \brief read out the event TOFs and clear the vector
+  std::vector<uint32_t> readOutTOFs() {
+    return mTOFs;
+    mTOFs.clear();
+  }
+
+private:
+  RdKafka::Conf *mConf;
+  RdKafka::Conf *mTConf;
+  RdKafka::KafkaConsumer *mConsumer;
+  RdKafka::Topic *mTopic;
+
+  // Thread safe histogram data storage
+  ThreadSafeVector<uint32_t> mHistogram;
+  ThreadSafeVector<uint32_t> mHistogramTof;
+  ThreadSafeVector<uint32_t> mPixelIDs;
+  ThreadSafeVector<uint32_t> mTOFs;
+
+  /// \brief configuration obtained from main()
+  Configuration &mConfig;
+
+  /// \brief loadable Kafka-specific configuration
+  std::vector<std::pair<std::string, std::string>> &mKafkaConfig;
+
   /// \brief histograms the event pixelids and ignores TOF
   uint32_t processEV42Data(RdKafka::Message *Msg);
 
@@ -42,32 +124,6 @@ public:
 
   /// \brief histograms the DA00 TOF data bins
   uint32_t processDA00Data(RdKafka::Message *Msg);
-
-  /// \brief return a random group id so that simultaneous consume from
-  /// multiple applications is possible.
-  static std::string randomGroupString(size_t length);
-
-  // Histogram(s) and counts
-  ThreadSafeVector<uint32_t> mHistogram;
-  ThreadSafeVector<uint32_t> mHistogramTof;
-  ThreadSafeVector<uint32_t> mPixelIDs;
-  ThreadSafeVector<uint32_t> mTOFs;
-
-  uint64_t EventCount{0};
-  uint64_t EventAccept{0};
-  uint64_t EventDiscard{0};
-
-private:
-  RdKafka::Conf *mConf;
-  RdKafka::Conf *mTConf;
-  RdKafka::KafkaConsumer *mConsumer;
-  RdKafka::Topic *mTopic;
-
-  /// \brief configuration obtained from main()
-  Configuration &mConfig;
-
-  /// \brief loadable Kafka-specific configuration
-  std::vector<std::pair<std::string, std::string>> &mKafkaConfig;
 
   std::vector<int64_t> getDataVector(const da00_Variable &Variable) const;
 

--- a/src/daqlite/ESSConsumer.h
+++ b/src/daqlite/ESSConsumer.h
@@ -10,11 +10,11 @@
 
 #pragma once
 
+#include <Configuration.h>
 #include <ThreadSafeVector.h>
+#include <cstdint>
 #include <da00_dataarray_generated.h>
 #include <flatbuffers/flatbuffers.h>
-#include <Configuration.h>
-#include <cstdint>
 #include <librdkafka/rdkafkacpp.h>
 #include <mutex>
 #include <string>
@@ -78,14 +78,14 @@ public:
   /// \brief read out the histogram data and reset it
   std::vector<uint32_t> readResetHistogram() {
     std::vector<uint32_t> ret = mHistogram;
-    mHistogram = std::vector<uint32_t>(mConfig.TOF.BinSize, 0);
+    mHistogram.clear();
     return ret;
   }
 
   /// \brief read out the TOF histogram data and reset it
   std::vector<uint32_t> readResetHistogramTof() {
     std::vector<uint32_t> ret = mHistogramTof;
-    mHistogramTof.fill(0);
+    mHistogramTof.clear();
     return ret;
   }
 
@@ -115,10 +115,10 @@ private:
   RdKafka::Topic *mTopic;
 
   // Thread safe histogram data storage
-  ThreadSafeVector<uint32_t> mHistogram;
-  ThreadSafeVector<uint32_t> mHistogramTof;
-  ThreadSafeVector<uint32_t> mPixelIDs;
-  ThreadSafeVector<uint32_t> mTOFs;
+  ThreadSafeVector<uint32_t, int64_t> mHistogram;
+  ThreadSafeVector<uint32_t, int64_t> mHistogramTof;
+  ThreadSafeVector<uint32_t, int64_t> mPixelIDs;
+  ThreadSafeVector<uint32_t, int64_t> mTOFs;
 
   /// \brief configuration obtained from main()
   Configuration &mConfig;

--- a/src/daqlite/ESSConsumer.h
+++ b/src/daqlite/ESSConsumer.h
@@ -10,10 +10,12 @@
 
 #pragma once
 
+#include "ThreadSafeVector.h"
 #include "da00_dataarray_generated.h"
 #include "flatbuffers/flatbuffers.h"
 #include <Configuration.h>
 #include <librdkafka/rdkafkacpp.h>
+#include <mutex>
 #include <string>
 
 class ESSConsumer {
@@ -23,7 +25,7 @@ public:
               std::vector<std::pair<std::string, std::string>> &KafkaConfig);
 
   /// \brief wrapper function for librdkafka consumer
-  RdKafka::Message *consume();
+  std::unique_ptr<RdKafka::Message> consume();
 
   /// \brief setup librdkafka parameters for Broker and Topic
   RdKafka::KafkaConsumer *subscribeTopic() const;
@@ -46,15 +48,10 @@ public:
   static std::string randomGroupString(size_t length);
 
   // Histogram(s) and counts
-  std::vector<uint32_t> mHistogramPlot;
-  std::vector<uint32_t> mHistogram;
-  std::vector<uint32_t> mHistogramTofPlot;
-  std::vector<uint32_t> mHistogramTof;
-
-  std::vector<uint32_t> mPixelIDs;
-  std::vector<uint32_t> mPixelIDsPlot;
-  std::vector<uint32_t> mTOFs;
-  std::vector<uint32_t> mTOFsPlot;
+  ThreadSafeVector<uint32_t> mHistogram;
+  ThreadSafeVector<uint32_t> mHistogramTof;
+  ThreadSafeVector<uint32_t> mPixelIDs;
+  ThreadSafeVector<uint32_t> mTOFs;
 
   uint64_t EventCount{0};
   uint64_t EventAccept{0};

--- a/src/daqlite/ESSConsumer.h
+++ b/src/daqlite/ESSConsumer.h
@@ -78,7 +78,7 @@ public:
   /// \brief read out the histogram data and reset it
   std::vector<uint32_t> readResetHistogram() {
     std::vector<uint32_t> ret = mHistogram;
-    mHistogram.fill(0);
+    mHistogram = std::vector<uint32_t>(mConfig.TOF.BinSize, 0);
     return ret;
   }
 

--- a/src/daqlite/ESSConsumer.h
+++ b/src/daqlite/ESSConsumer.h
@@ -18,6 +18,7 @@
 #include <librdkafka/rdkafkacpp.h>
 #include <mutex>
 #include <string>
+#include <vector>
 
 /// \class ESSConsumer
 /// \brief A class to handle Kafka consumer operations for ESS data.
@@ -75,27 +76,36 @@ public:
   uint64_t EventDiscard{0};
 
   /// \brief read out the histogram data and reset it
-  std::vector<uint32_t> readOutHistogram() {
-    return mHistogram;
+  std::vector<uint32_t> readResetHistogram() {
+    std::vector<uint32_t> ret = mHistogram;
     mHistogram.fill(0);
+    return ret;
   }
 
   /// \brief read out the TOF histogram data and reset it
-  std::vector<uint32_t> readOutHistogramTof() {
-    return mHistogramTof;
+  std::vector<uint32_t> readResetHistogramTof() {
+    std::vector<uint32_t> ret = mHistogramTof;
     mHistogramTof.fill(0);
+    return ret;
   }
 
   /// \brief read out the event pixel IDs and clear the vector
-  std::vector<uint32_t> readOutPixelIDs() {
-    return mPixelIDs;
+  std::vector<uint32_t> readResetPixelIDs() {
+    std::vector<uint32_t> ret = mPixelIDs;
     mPixelIDs.clear();
+    return ret;
   }
 
   /// \brief read out the event TOFs and clear the vector
-  std::vector<uint32_t> readOutTOFs() {
-    return mTOFs;
+  std::vector<uint32_t> readResetTOFs() {
+    std::vector<uint32_t> ret = mTOFs;
     mTOFs.clear();
+    return ret;
+  }
+
+  std::vector<uint32_t> getTofs() const {
+    std::vector<uint32_t> ret = mTOFs;
+    return ret;
   }
 
 private:

--- a/src/daqlite/HistogramPlot.cpp
+++ b/src/daqlite/HistogramPlot.cpp
@@ -5,6 +5,8 @@
 ///
 //===----------------------------------------------------------------------===//
 
+#include "AbstractPlot.h"
+#include "ESSConsumer.h"
 #include <HistogramPlot.h>
 #include <QPlot/qcustomplot/qcustomplot.h>
 #include <WorkerThread.h>
@@ -13,7 +15,8 @@
 #include <fmt/format.h>
 #include <string>
 
-HistogramPlot::HistogramPlot(Configuration &Config) : mConfig(Config) {
+HistogramPlot::HistogramPlot(Configuration &Config, ESSConsumer &Consumer)
+    : AbstractPlot(HISTOGRAM, Consumer), mConfig(Config) {
 
   // Register callback functions for events
   connect(this, SIGNAL(mouseMove(QMouseEvent *)), this,
@@ -41,7 +44,7 @@ HistogramPlot::HistogramPlot(Configuration &Config) : mConfig(Config) {
   // mGraph->setLineStyle(QCPGraph::lsNone);
   mGraph->setBrush(QBrush(QColor(0, 0, 255, 20)));
   mGraph->setLineStyle(QCPGraph::lsStepCenter);
-  mGraph->  setScatterStyle(QCPScatterStyle(QCPScatterStyle::ssCircle, 5));
+  mGraph->setScatterStyle(QCPScatterStyle(QCPScatterStyle::ssCircle, 5));
 
   // we want the color map to have nx * ny data points
 
@@ -86,7 +89,7 @@ void HistogramPlot::plotDetectorImage(bool Force) {
   if (mConfig.TOF.AutoScaleX) {
     xAxis->setRange(0, mConfig.TOF.MaxValue * 1.05);
   }
-  if (mConfig.TOF.AutoScaleY){
+  if (mConfig.TOF.AutoScaleY) {
     yAxis->setRange(0, MaxY * 1.05);
   }
   replot();

--- a/src/daqlite/HistogramPlot.cpp
+++ b/src/daqlite/HistogramPlot.cpp
@@ -75,6 +75,7 @@ void HistogramPlot::plotDetectorImage(bool Force) {
   setCustomParameters();
   mGraph->data()->clear();
   uint32_t MaxY{1};
+
   for (unsigned int i = 0; i < HistogramXAxisValues.size(); i++) {
     if ((HistogramXAxisValues[i] != 0) or (Force)) {
       if (HistogramYAxisValues[i] > MaxY) {
@@ -103,10 +104,10 @@ void HistogramPlot::updateData() {
   auto t2 = std::chrono::high_resolution_clock::now();
   std::chrono::duration<int64_t, std::nano> elapsed = t2 - t1;
 
-  std::vector<uint32_t> YAxisValus = mConsumer.readResetHistogram();
+  std::vector<uint32_t> YAxisValues = mConsumer.readResetHistogram();
   HistogramXAxisValues = mConsumer.getTofs();
 
-  if (YAxisValus.size() != HistogramXAxisValues.size()) {
+  if (YAxisValues.size() != HistogramXAxisValues.size()) {
     fmt::print("HistogramPlot::updateData() - TOF and Count vectors are not "
                "the same size\n");
     return;
@@ -121,13 +122,13 @@ void HistogramPlot::updateData() {
     t1 = std::chrono::high_resolution_clock::now();
   }
 
-  if (HistogramYAxisValues.size() < YAxisValus.size()) {
-    HistogramYAxisValues.resize(YAxisValus.size());
+  if (HistogramYAxisValues.size() < YAxisValues.size()) {
+    HistogramYAxisValues.resize(YAxisValues.size());
   }
 
   // Accumulate counts, PixelId 0 does not exist
-  for (unsigned int i = 1; i < YAxisValus.size(); i++) {
-    HistogramYAxisValues[i] += YAxisValus[i];
+  for (unsigned int i = 1; i < YAxisValues.size(); i++) {
+    HistogramYAxisValues[i] += YAxisValues[i];
   }
 
   plotDetectorImage(false);

--- a/src/daqlite/HistogramPlot.cpp
+++ b/src/daqlite/HistogramPlot.cpp
@@ -5,8 +5,6 @@
 ///
 //===----------------------------------------------------------------------===//
 
-#include "AbstractPlot.h"
-#include "ESSConsumer.h"
 #include <HistogramPlot.h>
 #include <QPlot/qcustomplot/qcustomplot.h>
 #include <WorkerThread.h>
@@ -15,7 +13,6 @@
 #include <cstddef>
 #include <cstdint>
 #include <fmt/format.h>
-#include <qvector.h>
 #include <string>
 #include <vector>
 

--- a/src/daqlite/HistogramPlot.cpp
+++ b/src/daqlite/HistogramPlot.cpp
@@ -74,7 +74,7 @@ void HistogramPlot::setCustomParameters() {
 void HistogramPlot::plotDetectorImage(bool Force) {
   setCustomParameters();
   mGraph->data()->clear();
-  uint32_t MaxY{0};
+  uint32_t MaxY{1};
   for (unsigned int i = 0; i < HistogramXAxisValues.size(); i++) {
     if ((HistogramXAxisValues[i] != 0) or (Force)) {
       if (HistogramYAxisValues[i] > MaxY) {

--- a/src/daqlite/HistogramPlot.h
+++ b/src/daqlite/HistogramPlot.h
@@ -23,7 +23,7 @@ public:
 
   /// \brief adds histogram data, clears periodically then calls
   /// plotDetectorImage()
-  void addData(std::vector<uint32_t> &Histogram);
+  void updateData() override;
 
   /// \brief update plot based on (possibly dynamic) config settings
   void setCustomParameters();

--- a/src/daqlite/HistogramPlot.h
+++ b/src/daqlite/HistogramPlot.h
@@ -1,9 +1,10 @@
 // Copyright (C) 2020 - 2021 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
-/// \file CustomTofPlot.h
+/// \file HistogramPlot.h
 ///
-/// \brief Creates a QCustomPlot based on the configuration parameters
+/// \brief Creates a hiostogram plot based on QCustomPlot and
+///  on the configuration parameters
 //===----------------------------------------------------------------------===//
 
 #pragma once
@@ -14,16 +15,15 @@
 #include <chrono>
 #include <logical_geometry/ESSGeometry.h>
 
-class CustomTofPlot : public AbstractPlot {
+class HistogramPlot : public AbstractPlot {
   Q_OBJECT
 public:
-
   /// \brief plot needs the configurable plotting options
-  CustomTofPlot(Configuration &Config);
+  HistogramPlot(Configuration &Config);
 
   /// \brief adds histogram data, clears periodically then calls
   /// plotDetectorImage()
-  void updateData() override;
+  void addData(std::vector<uint32_t> &Histogram);
 
   /// \brief update plot based on (possibly dynamic) config settings
   void setCustomParameters();
@@ -33,7 +33,7 @@ public:
 
 public slots:
   void showPointToolTip(QMouseEvent *event);
-  
+
 private:
   /// \brief updates the image
   /// \param Force forces updates of histogram data with zero count

--- a/src/daqlite/HistogramPlot.h
+++ b/src/daqlite/HistogramPlot.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 - 2021 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2020 - 2024 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file HistogramPlot.h
@@ -9,7 +9,8 @@
 
 #pragma once
 
-#include "AbstractPlot.h"
+#include <AbstractPlot.h>
+#include <ESSConsumer.h>
 #include <Configuration.h>
 #include <QPlot/QPlot.h>
 #include <chrono>

--- a/src/daqlite/HistogramPlot.h
+++ b/src/daqlite/HistogramPlot.h
@@ -14,6 +14,8 @@
 #include <QPlot/QPlot.h>
 #include <chrono>
 #include <logical_geometry/ESSGeometry.h>
+#include <qvector.h>
+#include <vector>
 
 class HistogramPlot : public AbstractPlot {
   Q_OBJECT
@@ -45,7 +47,8 @@ private:
   /// \brief configuration obtained from main()
   Configuration &mConfig;
 
-  std::vector<uint32_t> HistogramTofData;
+  std::vector<uint32_t> HistogramYAxisValues;
+  std::vector<uint32_t> HistogramXAxisValues;
 
   /// \brief for calculating x, y, z from pixelid
   ESSGeometry *LogicalGeometry;

--- a/src/daqlite/HistogramPlot.h
+++ b/src/daqlite/HistogramPlot.h
@@ -19,7 +19,7 @@ class HistogramPlot : public AbstractPlot {
   Q_OBJECT
 public:
   /// \brief plot needs the configurable plotting options
-  HistogramPlot(Configuration &Config);
+  HistogramPlot(Configuration &Config, ESSConsumer &Consumer);
 
   /// \brief adds histogram data, clears periodically then calls
   /// plotDetectorImage()

--- a/src/daqlite/MainWindow.cpp
+++ b/src/daqlite/MainWindow.cpp
@@ -5,11 +5,11 @@
 ///
 //===----------------------------------------------------------------------===//
 
-#include "AbstractPlot.h"
-#include "CustomAMOR2DTOFPlot.h"
-#include "CustomTofPlot.h"
-#include "HistogramPlot.h"
-#include "ui_MainWindow.h"
+#include <HistogramPlot.h>
+#include <Custom2DPlot.h>
+#include <CustomAMOR2DTOFPlot.h>
+#include <CustomTofPlot.h>
+#include <ui_MainWindow.h>
 #include <MainWindow.h>
 #include <memory>
 #include <string.h>

--- a/src/daqlite/MainWindow.cpp
+++ b/src/daqlite/MainWindow.cpp
@@ -5,6 +5,7 @@
 ///
 //===----------------------------------------------------------------------===//
 
+#include "AbstractPlot.h"
 #include <HistogramPlot.h>
 #include <Custom2DPlot.h>
 #include <CustomAMOR2DTOFPlot.h>
@@ -113,6 +114,11 @@ void MainWindow::setupPlots() {
     ui->lblAutoScaleYText->setVisible(true);
     ui->lblAutoScaleY->setVisible(true);
   }
+
+  if (Plots[0]->getPlotType() == HISTOGRAM) {
+    ui->lblBinSizeText->setVisible(true);
+    ui->lblBinSize->setVisible(true);
+  }
 }
 
 void MainWindow::startKafkaConsumerThread() {
@@ -133,6 +139,7 @@ void MainWindow::handleKafkaData(int ElapsedCountMS) {
   ui->lblEventRateText->setText(QString::number(EventRate));
   ui->lblAcceptRateText->setText(QString::number(EventAccept));
   ui->lblDiscardedPixelsText->setText(QString::number(EventDiscardRate));
+  ui->lblBinSizeText->setText(QString::number(mConfig.TOF.BinSize));
 
   for (auto &Plot : Plots) {
     Plot->updateData();

--- a/src/daqlite/MainWindow.cpp
+++ b/src/daqlite/MainWindow.cpp
@@ -15,13 +15,15 @@
 
 void MainWindow::setupPlots() {
   if (strcmp(mConfig.Plot.PlotType.c_str(), "tof2d") == 0) {
-    Plots.push_back(std::make_unique<CustomAMOR2DTOFPlot>(mConfig));
+    Plots.push_back(std::make_unique<CustomAMOR2DTOFPlot>(
+        mConfig, KafkaConsumerThread->getConsumer()));
 
     // register plot on ui
     registerPlot(Plots.back().get());
 
   } else if (strcmp(mConfig.Plot.PlotType.c_str(), "tof") == 0) {
-    Plots.push_back(std::make_unique<CustomTofPlot>(mConfig));
+    Plots.push_back(std::make_unique<CustomTofPlot>(
+        mConfig, KafkaConsumerThread->getConsumer()));
 
     // register plot on ui
     registerPlot(Plots.back().get());
@@ -35,18 +37,21 @@ void MainWindow::setupPlots() {
   } else if (strcmp(mConfig.Plot.PlotType.c_str(), "pixels") == 0) {
 
     // Always create the XY plot
-    Plots.push_back(
-        std::make_unique<Custom2DPlot>(mConfig, Custom2DPlot::ProjectionXY));
+    Plots.push_back(std::make_unique<Custom2DPlot>(
+        mConfig, KafkaConsumerThread->getConsumer(),
+        Custom2DPlot::ProjectionXY));
 
     registerPlot(Plots.back().get());
 
     // If detector is 3D, also create XZ and YZ
     if (mConfig.Geometry.ZDim > 1) {
-      Plots.push_back(
-          std::make_unique<Custom2DPlot>(mConfig, Custom2DPlot::ProjectionXZ));
+      Plots.push_back(std::make_unique<Custom2DPlot>(
+          mConfig, KafkaConsumerThread->getConsumer(),
+          Custom2DPlot::ProjectionXZ));
       registerPlot(Plots.back().get());
-      Plots.push_back(
-          std::make_unique<Custom2DPlot>(mConfig, Custom2DPlot::ProjectionYZ));
+      Plots.push_back(std::make_unique<Custom2DPlot>(
+          mConfig, KafkaConsumerThread->getConsumer(),
+          Custom2DPlot::ProjectionYZ));
       registerPlot(Plots.back().get());
     }
   } else {
@@ -71,7 +76,8 @@ void MainWindow::registerPlot(AbstractPlot *Plot) const {
 }
 
 MainWindow::MainWindow(Configuration &Config, QWidget *parent)
-    : QMainWindow(parent), ui(new Ui::MainWindow), mConfig(Config) {
+    : QMainWindow(parent), ui(new Ui::MainWindow), mConfig(Config),
+      KafkaConsumerThread(std::make_unique<WorkerThread>(Config)) {
 
   ui->setupUi(this);
 
@@ -103,34 +109,32 @@ MainWindow::MainWindow(Configuration &Config, QWidget *parent)
 MainWindow::~MainWindow() { delete ui; }
 
 void MainWindow::startKafkaConsumerThread() {
-  KafkaConsumerThread = new WorkerThread(mConfig);
   qRegisterMetaType<int>("int&");
-  connect(KafkaConsumerThread, &WorkerThread::resultReady, this,
+  connect(KafkaConsumerThread.get(), &WorkerThread::resultReady, this,
           &MainWindow::handleKafkaData);
   KafkaConsumerThread->start();
 }
 
 // SLOT
 void MainWindow::handleKafkaData(int ElapsedCountMS) {
-  auto Consumer = KafkaConsumerThread->consumer();
+  auto &Consumer = KafkaConsumerThread->getConsumer();
 
-  uint64_t EventRate = Consumer->EventCount * 1000ULL / ElapsedCountMS;
-  uint64_t EventAccept = Consumer->EventAccept * 1000ULL / ElapsedCountMS;
-  uint64_t EventDiscardRate = Consumer->EventDiscard * 1000ULL / ElapsedCountMS;
+  uint64_t EventRate = Consumer.EventCount * 1000ULL / ElapsedCountMS;
+  uint64_t EventAccept = Consumer.EventAccept * 1000ULL / ElapsedCountMS;
+  uint64_t EventDiscardRate = Consumer.EventDiscard * 1000ULL / ElapsedCountMS;
 
   ui->lblEventRateText->setText(QString::number(EventRate));
   ui->lblAcceptRateText->setText(QString::number(EventAccept));
   ui->lblDiscardedPixelsText->setText(QString::number(EventDiscardRate));
-
 
   for (auto &Plot : Plots) {
     Plot->updateData();
     Plot->plotDetectorImage(false);
   }
 
-  Consumer->EventCount = 0;
-  Consumer->EventAccept = 0;
-  Consumer->EventDiscard = 0;
+  Consumer.EventCount = 0;
+  Consumer.EventAccept = 0;
+  Consumer.EventDiscard = 0;
 }
 
 // SLOT

--- a/src/daqlite/MainWindow.cpp
+++ b/src/daqlite/MainWindow.cpp
@@ -13,6 +13,39 @@
 #include <memory>
 #include <string.h>
 
+MainWindow::MainWindow(Configuration &Config, QWidget *parent)
+    : QMainWindow(parent), ui(new Ui::MainWindow), mConfig(Config),
+      KafkaConsumerThread(std::make_unique<WorkerThread>(Config)) {
+
+  ui->setupUi(this);
+
+  setupPlots();
+
+  ui->lblDescriptionText->setText(mConfig.Plot.PlotTitle.c_str());
+  ui->lblEventRateText->setText("0");
+
+  connect(ui->pushButtonQuit, SIGNAL(clicked()), this,
+          SLOT(handleExitButton()));
+  connect(ui->pushButtonClear, SIGNAL(clicked()), this,
+          SLOT(handleClearButton()));
+  connect(ui->pushButtonLog, SIGNAL(clicked()), this, SLOT(handleLogButton()));
+  connect(ui->pushButtonGradient, SIGNAL(clicked()), this,
+          SLOT(handleGradientButton()));
+  connect(ui->pushButtonInvert, SIGNAL(clicked()), this,
+          SLOT(handleInvertButton()));
+  connect(ui->pushButtonAutoScaleX, SIGNAL(clicked()), this,
+          SLOT(handleAutoScaleXButton()));
+  connect(ui->pushButtonAutoScaleY, SIGNAL(clicked()), this,
+          SLOT(handleAutoScaleYButton()));
+
+  updateGradientLabel();
+  updateAutoScaleLabels();
+  show();
+  startKafkaConsumerThread();
+}
+
+MainWindow::~MainWindow() {delete ui;}
+
 void MainWindow::setupPlots() {
   if (strcmp(mConfig.Plot.PlotType.c_str(), "tof2d") == 0) {
     Plots.push_back(std::make_unique<CustomAMOR2DTOFPlot>(
@@ -74,39 +107,6 @@ void MainWindow::registerPlot(AbstractPlot *Plot) const {
     ui->gridLayout->addWidget(Plot, 0, 0, 1, 1);
   }
 }
-
-MainWindow::MainWindow(Configuration &Config, QWidget *parent)
-    : QMainWindow(parent), ui(new Ui::MainWindow), mConfig(Config),
-      KafkaConsumerThread(std::make_unique<WorkerThread>(Config)) {
-
-  ui->setupUi(this);
-
-  setupPlots();
-
-  ui->lblDescriptionText->setText(mConfig.Plot.PlotTitle.c_str());
-  ui->lblEventRateText->setText("0");
-
-  connect(ui->pushButtonQuit, SIGNAL(clicked()), this,
-          SLOT(handleExitButton()));
-  connect(ui->pushButtonClear, SIGNAL(clicked()), this,
-          SLOT(handleClearButton()));
-  connect(ui->pushButtonLog, SIGNAL(clicked()), this, SLOT(handleLogButton()));
-  connect(ui->pushButtonGradient, SIGNAL(clicked()), this,
-          SLOT(handleGradientButton()));
-  connect(ui->pushButtonInvert, SIGNAL(clicked()), this,
-          SLOT(handleInvertButton()));
-  connect(ui->pushButtonAutoScaleX, SIGNAL(clicked()), this,
-          SLOT(handleAutoScaleXButton()));
-  connect(ui->pushButtonAutoScaleY, SIGNAL(clicked()), this,
-          SLOT(handleAutoScaleYButton()));
-
-  updateGradientLabel();
-  updateAutoScaleLabels();
-  show();
-  startKafkaConsumerThread();
-}
-
-MainWindow::~MainWindow() { delete ui; }
 
 void MainWindow::startKafkaConsumerThread() {
   qRegisterMetaType<int>("int&");

--- a/src/daqlite/MainWindow.cpp
+++ b/src/daqlite/MainWindow.cpp
@@ -5,21 +5,26 @@
 ///
 //===----------------------------------------------------------------------===//
 
+#include "AbstractPlot.h"
+#include "CustomAMOR2DTOFPlot.h"
+#include "CustomTofPlot.h"
 #include "ui_MainWindow.h"
 #include <MainWindow.h>
+#include <memory>
 #include <string.h>
-
 
 void MainWindow::setupPlots() {
   if (strcmp(mConfig.Plot.PlotType.c_str(), "tof2d") == 0) {
-    plottype = tof2d;
-    PlotTOF2D = new CustomAMOR2DTOFPlot(mConfig);
-    ui->gridLayout->addWidget(PlotTOF2D, 0, 0, 1, 1);
+    Plots.push_back(std::make_unique<CustomAMOR2DTOFPlot>(mConfig));
+
+    // register plot on ui
+    registerPlot(Plots.back().get());
 
   } else if (strcmp(mConfig.Plot.PlotType.c_str(), "tof") == 0) {
-    plottype =tof;
-    PlotTOF = new CustomTofPlot(mConfig);
-    ui->gridLayout->addWidget(PlotTOF, 0, 0, 1, 1);
+    Plots.push_back(std::make_unique<CustomTofPlot>(mConfig));
+
+    // register plot on ui
+    registerPlot(Plots.back().get());
 
     // Hide irrelevant buttons for TOF
     ui->pushButtonGradient->setVisible(false);
@@ -28,30 +33,40 @@ void MainWindow::setupPlots() {
     ui->lblGradient->setVisible(false);
 
   } else if (strcmp(mConfig.Plot.PlotType.c_str(), "pixels") == 0) {
-    plottype =pixels;
 
     // Always create the XY plot
-    Plot2DXY = new Custom2DPlot(mConfig, Custom2DPlot::ProjectionXY);
-    ui->gridLayout->addWidget(Plot2DXY, 0, 0, 1, 1);
+    Plots.push_back(
+        std::make_unique<Custom2DPlot>(mConfig, Custom2DPlot::ProjectionXY));
+
+    registerPlot(Plots.back().get());
+
     // If detector is 3D, also create XZ and YZ
     if (mConfig.Geometry.ZDim > 1) {
-      Plot2DXZ = new Custom2DPlot(mConfig, Custom2DPlot::ProjectionXZ);
-      ui->gridLayout->addWidget(Plot2DXZ, 0, 1, 1, 1);
-      Plot2DYZ = new Custom2DPlot(mConfig, Custom2DPlot::ProjectionYZ);
-      ui->gridLayout->addWidget(Plot2DYZ, 0, 2, 1, 1);
+      Plots.push_back(
+          std::make_unique<Custom2DPlot>(mConfig, Custom2DPlot::ProjectionXZ));
+      registerPlot(Plots.back().get());
+      Plots.push_back(
+          std::make_unique<Custom2DPlot>(mConfig, Custom2DPlot::ProjectionYZ));
+      registerPlot(Plots.back().get());
     }
   } else {
     throw(std::runtime_error("No valid plot type specified"));
   }
 
   // Autoscale buttons are only relevant for TOF
-  if (plottype != tof) {
+  if (Plots[0]->getPlotType() == TOF) {
     ui->pushButtonAutoScaleX->setVisible(false);
     ui->lblAutoScaleXText->setVisible(false);
     ui->lblAutoScaleX->setVisible(false);
     ui->pushButtonAutoScaleY->setVisible(false);
     ui->lblAutoScaleYText->setVisible(false);
     ui->lblAutoScaleY->setVisible(false);
+  }
+}
+
+void MainWindow::registerPlot(AbstractPlot *Plot) const {
+  if (Plot != nullptr) {
+    ui->gridLayout->addWidget(Plot, 0, 0, 1, 1);
   }
 }
 
@@ -99,70 +114,53 @@ void MainWindow::startKafkaConsumerThread() {
 void MainWindow::handleKafkaData(int ElapsedCountMS) {
   auto Consumer = KafkaConsumerThread->consumer();
 
-  uint64_t EventRate = Consumer->EventCount * 1000ULL/ElapsedCountMS;
-  uint64_t EventAccept = Consumer->EventAccept * 1000ULL/ElapsedCountMS;
-  uint64_t EventDiscardRate = Consumer->EventDiscard * 1000ULL/ElapsedCountMS;
+  uint64_t EventRate = Consumer->EventCount * 1000ULL / ElapsedCountMS;
+  uint64_t EventAccept = Consumer->EventAccept * 1000ULL / ElapsedCountMS;
+  uint64_t EventDiscardRate = Consumer->EventDiscard * 1000ULL / ElapsedCountMS;
 
   ui->lblEventRateText->setText(QString::number(EventRate));
   ui->lblAcceptRateText->setText(QString::number(EventAccept));
   ui->lblDiscardedPixelsText->setText(QString::number(EventDiscardRate));
 
-  KafkaConsumerThread->mutex.lock();
 
-  if (plottype == tof2d) {
-    PlotTOF2D->addData(Consumer->mPixelIDsPlot, Consumer->mTOFsPlot);
-  } else if (plottype == tof) {
-    PlotTOF->addData(Consumer->mHistogramTofPlot);
-  } else if (plottype == pixels) {
-    Plot2DXY->addData(Consumer->mHistogramPlot);
-    if (mConfig.Geometry.ZDim > 1) {
-      Plot2DXZ->addData(Consumer->mHistogramPlot);
-      Plot2DYZ->addData(Consumer->mHistogramPlot);
-    }
+  for (auto &Plot : Plots) {
+    Plot->updateData();
+    Plot->plotDetectorImage(false);
   }
 
   Consumer->EventCount = 0;
   Consumer->EventAccept = 0;
   Consumer->EventDiscard = 0;
-  KafkaConsumerThread->mutex.unlock();
 }
 
 // SLOT
 void MainWindow::handleExitButton() { QApplication::quit(); }
 
 void MainWindow::handleClearButton() {
-  if (plottype == tof2d) {
-    auto Consumer = KafkaConsumerThread->consumer();
-    PlotTOF2D->clearDetectorImage(Consumer->mPixelIDsPlot, Consumer->mTOFsPlot);
 
-  } else if (plottype == tof) {
-    PlotTOF->clearDetectorImage();
-
-  } else if (plottype == pixels) {
-    Plot2DXY->clearDetectorImage();
-    if (mConfig.Geometry.ZDim > 1) {
-      Plot2DXZ->clearDetectorImage();
-      Plot2DYZ->clearDetectorImage();
-    }
+  for (auto &Plot : Plots) {
+    Plot->clearDetectorImage();
   }
 }
 
 void MainWindow::updateGradientLabel() {
-  if (plottype != tof) {
-    if (mConfig.Plot.InvertGradient) {
-      ui->lblGradientText->setText(
-          QString::fromStdString(mConfig.Plot.ColorGradient + " (I)"));
-    } else {
-      ui->lblGradientText->setText(
-          QString::fromStdString(mConfig.Plot.ColorGradient));
+
+  for (auto &Plot : Plots) {
+    if (Plot->getPlotType() != TOF) {
+      if (mConfig.Plot.InvertGradient) {
+        ui->lblGradientText->setText(
+            QString::fromStdString(mConfig.Plot.ColorGradient + " (I)"));
+      } else {
+        ui->lblGradientText->setText(
+            QString::fromStdString(mConfig.Plot.ColorGradient));
+      }
     }
   }
 }
 
-
 /// \brief Autoscale is only relevant for TOF
 void MainWindow::updateAutoScaleLabels() {
-  if (plottype == tof) {
+  if (Plots[0]->getPlotType() != TOF) {
     if (mConfig.TOF.AutoScaleX) {
       ui->lblAutoScaleXText->setText(QString::fromStdString("on"));
     } else {
@@ -184,7 +182,7 @@ void MainWindow::handleLogButton() {
 
 // toggle the invert gradient flag (irrelevant for TOF)
 void MainWindow::handleInvertButton() {
-  if (plottype != tof) {
+  if (Plots[0]->getPlotType() != TOF) {
     mConfig.Plot.InvertGradient = not mConfig.Plot.InvertGradient;
     updateGradientLabel();
   }
@@ -192,7 +190,7 @@ void MainWindow::handleInvertButton() {
 
 // toggle the auto scale x button
 void MainWindow::handleAutoScaleXButton() {
-  if (plottype == tof) {
+  if (Plots[0]->getPlotType() == TOF) {
     mConfig.TOF.AutoScaleX = not mConfig.TOF.AutoScaleX;
     updateAutoScaleLabels();
   }
@@ -200,22 +198,37 @@ void MainWindow::handleAutoScaleXButton() {
 
 // toggle the auto scale y button
 void MainWindow::handleAutoScaleYButton() {
-  if (plottype == tof) {
+  if (Plots[0]->getPlotType() == TOF) {
     mConfig.TOF.AutoScaleY = not mConfig.TOF.AutoScaleY;
     updateAutoScaleLabels();
   }
 }
 
 void MainWindow::handleGradientButton() {
-  if (plottype == pixels) {
-    mConfig.Plot.ColorGradient =
-      Plot2DXY->getNextColorGradient(mConfig.Plot.ColorGradient);
-  } else if (plottype == tof2d) {
-    mConfig.Plot.ColorGradient =
-      PlotTOF2D->getNextColorGradient(mConfig.Plot.ColorGradient);
-    PlotTOF2D->plotDetectorImage(true);
-  } else {
-    return;
+
+  for (auto &Plot : Plots) {
+    if (Plot->getPlotType() == PIXEL) {
+
+      Custom2DPlot *Plot2D = dynamic_cast<Custom2DPlot *>(Plot.get());
+
+      /// \todo unnecessary code here could be part of the object since it has
+      /// the config at construction
+      mConfig.Plot.ColorGradient =
+          Plot2D->getNextColorGradient(mConfig.Plot.ColorGradient);
+
+    } else if (Plot->getPlotType() != TOF2D) {
+
+      CustomAMOR2DTOFPlot *PlotTOF2D =
+          dynamic_cast<CustomAMOR2DTOFPlot *>(Plot.get());
+
+      mConfig.Plot.ColorGradient =
+          PlotTOF2D->getNextColorGradient(mConfig.Plot.ColorGradient);
+
+    } else {
+      return;
+    }
+
+    Plot->plotDetectorImage(true);
   }
   updateGradientLabel();
 }

--- a/src/daqlite/MainWindow.h
+++ b/src/daqlite/MainWindow.h
@@ -70,5 +70,5 @@ private:
   Configuration mConfig;
 
   /// \brief
-  WorkerThread *KafkaConsumerThread;
+  std::unique_ptr<WorkerThread> KafkaConsumerThread;
 };

--- a/src/daqlite/MainWindow.h
+++ b/src/daqlite/MainWindow.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 - 2022 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2020 - 2024 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file MainWindow.h
@@ -10,9 +10,6 @@
 
 #include <AbstractPlot.h>
 #include <Configuration.h>
-#include <Custom2DPlot.h>
-#include <CustomAMOR2DTOFPlot.h>
-#include <CustomTofPlot.h>
 #include <QMainWindow>
 #include <WorkerThread.h>
 #include <memory>

--- a/src/daqlite/MainWindow.h
+++ b/src/daqlite/MainWindow.h
@@ -8,12 +8,14 @@
 
 #pragma once
 
+#include <AbstractPlot.h>
 #include <Configuration.h>
 #include <Custom2DPlot.h>
 #include <CustomAMOR2DTOFPlot.h>
 #include <CustomTofPlot.h>
 #include <QMainWindow>
 #include <WorkerThread.h>
+#include <memory>
 
 QT_BEGIN_NAMESPACE
 namespace Ui {
@@ -23,6 +25,11 @@ QT_END_NAMESPACE
 
 class MainWindow : public QMainWindow {
   Q_OBJECT
+
+  // typedef std::variant<std::unique_ptr<Custom2DPlot>,
+  //                      std::unique_ptr<CustomAMOR2DTOFPlot>,
+  //                      std::unique_ptr<CustomTofPlot>>
+  //     PlotVariants;
 
 public:
   MainWindow(Configuration &Config, QWidget *parent = nullptr);
@@ -52,21 +59,16 @@ public slots:
 
 private:
   Ui::MainWindow *ui;
-  enum PlotType {none, pixels, tof, tof2d};
-  PlotType plottype{none};
 
-  CustomAMOR2DTOFPlot *PlotTOF2D; /// Experimental
-  Custom2DPlot *Plot2DXY; // xy plots
-  Custom2DPlot *Plot2DXZ; // xz plots
-  Custom2DPlot *Plot2DYZ; // yz plots
-  CustomTofPlot *PlotTOF;
+  std::vector<std::unique_ptr<AbstractPlot>> Plots;
 
-  //Q3DScatter scatter;
+  void registerPlot(AbstractPlot* Plot) const;
+
+  // Q3DScatter scatter;
 
   /// \brief configuration obtained from main()
   Configuration mConfig;
 
   /// \brief
   WorkerThread *KafkaConsumerThread;
-
 };

--- a/src/daqlite/MainWindow.h
+++ b/src/daqlite/MainWindow.h
@@ -62,8 +62,6 @@ private:
 
   std::vector<std::unique_ptr<AbstractPlot>> Plots;
 
-  void registerPlot(AbstractPlot* Plot) const;
-
   // Q3DScatter scatter;
 
   /// \brief configuration obtained from main()

--- a/src/daqlite/MainWindow.h
+++ b/src/daqlite/MainWindow.h
@@ -62,7 +62,7 @@ private:
   // Q3DScatter scatter;
 
   /// \brief configuration obtained from main()
-  Configuration mConfig;
+  Configuration &mConfig;
 
   /// \brief
   std::unique_ptr<WorkerThread> KafkaConsumerThread;

--- a/src/daqlite/MainWindow.ui
+++ b/src/daqlite/MainWindow.ui
@@ -232,6 +232,32 @@
         </property>
        </widget>
       </item>
+      <item>
+       <widget class="QLabel" name="lblBinSize">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Bins:</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="lblBinSizeText">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
      </layout>
     </item>
     <item>

--- a/src/daqlite/ThreadSafeVector.h
+++ b/src/daqlite/ThreadSafeVector.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <vector>
+#include <map>
 #include <mutex>
 #include <cstdint>
 

--- a/src/daqlite/ThreadSafeVector.h
+++ b/src/daqlite/ThreadSafeVector.h
@@ -1,0 +1,77 @@
+// Copyright (C) 2022 European Spallation Source, ERIC. See LICENSE file
+//===----------------------------------------------------------------------===//
+///
+/// \file CustomAMOR2DTOFPlot.h
+///
+/// \brief Creates (maybe) a QCustomPlot based on the configuration parameters
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include <vector>
+#include <mutex>
+#include <cstdint>
+
+template <typename T>
+class ThreadSafeVector {
+public:
+    void push_back(const T& value) {
+        std::lock_guard<std::mutex> lock(mMutex);
+        mVector.push_back(value);
+    }
+
+    std::vector<T> get() const {
+        std::lock_guard<std::mutex> lock(mMutex);
+        return mVector;
+    }
+
+    T at(const size_t index) const {
+        std::lock_guard<std::mutex> lock(mMutex);
+        return mVector.at(index);
+    }
+
+    size_t size() const {
+        std::lock_guard<std::mutex> lock(mMutex);
+        return mVector.size();
+    }
+
+    void clear() {
+        std::lock_guard<std::mutex> lock(mMutex);
+        mVector.clear();
+    }
+
+    void resize(const size_t newSize) {
+        std::lock_guard<std::mutex> lock(mMutex);
+        mVector.resize(newSize);
+    }
+
+    void increment_element(const size_t index) {
+        std::lock_guard<std::mutex> lock(mMutex);
+        ++mVector[index];
+    }
+    
+    void add_to_element(const size_t index, const T& value) {
+        std::lock_guard<std::mutex> lock(mMutex);
+        mVector[index] += value;
+    }
+
+    void fill(const T& value) {
+        std::lock_guard<std::mutex> lock(mMutex);
+        std::fill(mVector.begin(), mVector.end(), value);
+    }
+
+    ThreadSafeVector<T>& operator=(const std::vector<T>& other) {
+        std::lock_guard<std::mutex> lock(mMutex);
+        mVector = other;
+        return *this;
+    }
+
+    operator std::vector<T>() const {
+        std::lock_guard<std::mutex> lock(mMutex);
+        return mVector;
+    }
+
+private:
+    mutable std::mutex mMutex;
+    std::vector<T> mVector;
+};

--- a/src/daqlite/ThreadSafeVector.h
+++ b/src/daqlite/ThreadSafeVector.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2024 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file CustomAMOR2DTOFPlot.h

--- a/src/daqlite/ThreadSafeVector.h
+++ b/src/daqlite/ThreadSafeVector.h
@@ -8,71 +8,89 @@
 
 #pragma once
 
-#include <vector>
+#include <cstdint>
 #include <map>
 #include <mutex>
-#include <cstdint>
+#include <vector>
 
-template <typename T>
-class ThreadSafeVector {
+template <typename T, typename R> class ThreadSafeVector {
 public:
-    void push_back(const T& value) {
-        std::lock_guard<std::mutex> lock(mMutex);
-        mVector.push_back(value);
-    }
+  void push_back(const T &value) {
+    std::lock_guard<std::mutex> lock(mMutex);
+    mVector.push_back(value);
+  }
 
-    std::vector<T> get() const {
-        std::lock_guard<std::mutex> lock(mMutex);
-        return mVector;
-    }
+  std::vector<T> get() const {
+    std::lock_guard<std::mutex> lock(mMutex);
+    return mVector;
+  }
 
-    T at(const size_t index) const {
-        std::lock_guard<std::mutex> lock(mMutex);
-        return mVector.at(index);
-    }
+  T at(const size_t index) const {
+    std::lock_guard<std::mutex> lock(mMutex);
+    return mVector.at(index);
+  }
 
-    size_t size() const {
-        std::lock_guard<std::mutex> lock(mMutex);
-        return mVector.size();
-    }
+  size_t size() const {
+    std::lock_guard<std::mutex> lock(mMutex);
+    return mVector.size();
+  }
 
-    void clear() {
-        std::lock_guard<std::mutex> lock(mMutex);
-        mVector.clear();
-    }
+  void clear() {
+    std::lock_guard<std::mutex> lock(mMutex);
+    mVector.clear();
+  }
 
-    void resize(const size_t newSize) {
-        std::lock_guard<std::mutex> lock(mMutex);
-        mVector.resize(newSize);
-    }
+  void resize(const size_t newSize) {
+    std::lock_guard<std::mutex> lock(mMutex);
+    mVector.resize(newSize);
+  }
 
-    void fill(const T& value) {
-        std::lock_guard<std::mutex> lock(mMutex);
-        std::fill(mVector.begin(), mVector.end(), value);
-    }
+  void fill(const T &value) {
+    std::lock_guard<std::mutex> lock(mMutex);
+    std::fill(mVector.begin(), mVector.end(), value);
+  }
 
-    void add_values(const std::vector<T>& other) {
-        std::lock_guard<std::mutex> lock(mMutex);
-        if (mVector.size() < other.size()) {
-            mVector.resize(other.size());
-        }
-        for (size_t i = 0; i < other.size(); ++i) {
-            mVector[i] += other[i];
-        }
+  void add_values(const std::vector<T> &other) {
+    std::lock_guard<std::mutex> lock(mMutex);
+    if (mVector.size() < other.size()) {
+      mVector.resize(other.size());
     }
+    for (size_t i = 0; i < other.size(); ++i) {
+      mVector[i] += other[i];
+    }
+  }
 
-    ThreadSafeVector<T>& operator=(const std::vector<T>& other) {
-        std::lock_guard<std::mutex> lock(mMutex);
-        mVector = other;
-        return *this;
+  void add_values(const std::vector<R> &other) {
+    std::lock_guard<std::mutex> lock(mMutex);
+    if (mVector.size() < other.size()) {
+      mVector.resize(other.size());
     }
+    for (size_t i = 0; i < other.size(); ++i) {
+      mVector[i] += static_cast<T>(other[i]);
+    }
+  }
 
-    operator std::vector<T>() const {
-        std::lock_guard<std::mutex> lock(mMutex);
-        return mVector;
+  ThreadSafeVector<T, R> &operator=(const std::vector<T> &other) {
+    std::lock_guard<std::mutex> lock(mMutex);
+    mVector = other;
+    return *this;
+  }
+
+  ThreadSafeVector<T, R> &operator=(const std::vector<R> &other) {
+    std::lock_guard<std::mutex> lock(mMutex);
+    mVector.resize(other.size());
+    for (size_t i = 0; i < other.size(); ++i) {
+      mVector[i] = static_cast<T>(other[i]);
     }
+    return *this;
+  }
+
+  operator std::vector<T>() const {
+    std::lock_guard<std::mutex> lock(mMutex);
+    return mVector;
+  }
 
 private:
-    mutable std::mutex mMutex;
-    std::vector<T> mVector;
+  mutable std::mutex mMutex;
+  std::vector<T> mVector;
 };

--- a/src/daqlite/ThreadSafeVector.h
+++ b/src/daqlite/ThreadSafeVector.h
@@ -45,19 +45,19 @@ public:
         mVector.resize(newSize);
     }
 
-    void increment_element(const size_t index) {
-        std::lock_guard<std::mutex> lock(mMutex);
-        ++mVector[index];
-    }
-    
-    void add_to_element(const size_t index, const T& value) {
-        std::lock_guard<std::mutex> lock(mMutex);
-        mVector[index] += value;
-    }
-
     void fill(const T& value) {
         std::lock_guard<std::mutex> lock(mMutex);
         std::fill(mVector.begin(), mVector.end(), value);
+    }
+
+    void add_values(const std::vector<T>& other) {
+        std::lock_guard<std::mutex> lock(mMutex);
+        if (mVector.size() < other.size()) {
+            mVector.resize(other.size());
+        }
+        for (size_t i = 0; i < other.size(); ++i) {
+            mVector[i] += other[i];
+        }
     }
 
     ThreadSafeVector<T>& operator=(const std::vector<T>& other) {

--- a/src/daqlite/ThreadSafeVector.h
+++ b/src/daqlite/ThreadSafeVector.h
@@ -1,10 +1,14 @@
 // Copyright (C) 2024 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
-/// \file CustomAMOR2DTOFPlot.h
+/// \file ThreadSafeVector.h
 ///
-/// \brief Creates (maybe) a QCustomPlot based on the configuration parameters
-//===----------------------------------------------------------------------===//
+/// \brief This file contains the definition of the ThreadSafeVector template
+/// class.
+///
+/// The ThreadSafeVector class provides a thread-safe wrapper around a
+/// std::vector. It ensures that all operations on the vector are protected by a
+/// mutex, making it safe to use in a multi-threaded environment.
 
 #pragma once
 
@@ -13,44 +17,67 @@
 #include <mutex>
 #include <vector>
 
-template <typename T, typename R> class ThreadSafeVector {
+/// \class ThreadSafeVector
+/// \brief A thread-safe wrapper around std::vector.
+///
+/// \tparam DataType The type of elements stored in the vector.
+/// \tparam OtherDataType The type of elements in other vectors that can be
+/// added or assigned to this vector.
+template <typename DataType, typename OtherDataType> class ThreadSafeVector {
+
 public:
-  void push_back(const T &value) {
+  /// \brief Adds a value to the end of the vector.
+  /// \param value The value to be added.
+  void push_back(const DataType &value) {
     std::lock_guard<std::mutex> lock(mMutex);
     mVector.push_back(value);
   }
 
-  std::vector<T> get() const {
+  /// \brief Retrieves a copy of the vector.
+  /// \return A copy of the vector.
+  std::vector<DataType> get() const {
     std::lock_guard<std::mutex> lock(mMutex);
     return mVector;
   }
 
-  T at(const size_t index) const {
+  /// \brief Retrieves the element at the specified index.
+  /// \param index The index of the element to retrieve.
+  /// \return The element at the specified index.
+  DataType at(const size_t index) const {
     std::lock_guard<std::mutex> lock(mMutex);
     return mVector.at(index);
   }
 
+  /// \brief Retrieves the number of elements in the vector.
+  /// \return The number of elements in the vector.
   size_t size() const {
     std::lock_guard<std::mutex> lock(mMutex);
     return mVector.size();
   }
 
+  /// \brief Clears all elements from the vector.
   void clear() {
     std::lock_guard<std::mutex> lock(mMutex);
     mVector.clear();
   }
 
+  /// \brief Resizes the vector to the specified size.
+  /// \param newSize The new size of the vector.
   void resize(const size_t newSize) {
     std::lock_guard<std::mutex> lock(mMutex);
     mVector.resize(newSize);
   }
 
-  void fill(const T &value) {
+  /// \brief Fills the vector with the specified value.
+  /// \param value The value to fill the vector with.
+  void fill(const DataType &value) {
     std::lock_guard<std::mutex> lock(mMutex);
     std::fill(mVector.begin(), mVector.end(), value);
   }
 
-  void add_values(const std::vector<T> &other) {
+  /// \brief Adds values from another vector to this vector.
+  /// \param other The vector containing values to be added.
+  void add_values(const std::vector<DataType> &other) {
     std::lock_guard<std::mutex> lock(mMutex);
     if (mVector.size() < other.size()) {
       mVector.resize(other.size());
@@ -60,37 +87,49 @@ public:
     }
   }
 
-  void add_values(const std::vector<R> &other) {
+  /// \brief Adds values from another vector of a different type to this vector.
+  /// \param other The vector containing values to be added.
+  void add_values(const std::vector<OtherDataType> &other) {
     std::lock_guard<std::mutex> lock(mMutex);
     if (mVector.size() < other.size()) {
       mVector.resize(other.size());
     }
     for (size_t i = 0; i < other.size(); ++i) {
-      mVector[i] += static_cast<T>(other[i]);
+      mVector[i] += static_cast<DataType>(other[i]);
     }
   }
 
-  ThreadSafeVector<T, R> &operator=(const std::vector<T> &other) {
+  /// \brief Assigns values from another vector to this vector.
+  /// \param other The vector containing values to be assigned.
+  /// \return A reference to this vector.
+  ThreadSafeVector<DataType, OtherDataType> &
+  operator=(const std::vector<DataType> &other) {
     std::lock_guard<std::mutex> lock(mMutex);
     mVector = other;
     return *this;
   }
 
-  ThreadSafeVector<T, R> &operator=(const std::vector<R> &other) {
+  /// \brief Assigns values from another vector of a different type to this
+  /// vector. \param other The vector containing values to be assigned. \return
+  /// A reference to this vector.
+  ThreadSafeVector<DataType, OtherDataType> &
+  operator=(const std::vector<OtherDataType> &other) {
     std::lock_guard<std::mutex> lock(mMutex);
     mVector.resize(other.size());
     for (size_t i = 0; i < other.size(); ++i) {
-      mVector[i] = static_cast<T>(other[i]);
+      mVector[i] = static_cast<DataType>(other[i]);
     }
     return *this;
   }
 
-  operator std::vector<T>() const {
+  /// \brief Converts this vector to a std::vector.
+  /// \return A copy of the vector as a std::vector.
+  operator std::vector<DataType>() const {
     std::lock_guard<std::mutex> lock(mMutex);
     return mVector;
   }
 
 private:
   mutable std::mutex mMutex;
-  std::vector<T> mVector;
+  std::vector<DataType> mVector;
 };

--- a/src/daqlite/WorkerThread.cpp
+++ b/src/daqlite/WorkerThread.cpp
@@ -1,9 +1,9 @@
 // Copyright (C) 2022-2024 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
-/// \file CustomAMOR2DTOFPlot.h
+/// \file WorkerThread.cpp
 ///
-/// \brief Creates (maybe) a QCustomPlot based on the configuration parameters
+/// \brief main consumer loop implementation for Daquiri Light (daqlite)
 //===----------------------------------------------------------------------===//
 
 #include <WorkerThread.h>

--- a/src/daqlite/WorkerThread.cpp
+++ b/src/daqlite/WorkerThread.cpp
@@ -1,8 +1,9 @@
-// Copyright (C) 2020 - 2022 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2024 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
-/// \file WorkerThread.cpp
+/// \file CustomAMOR2DTOFPlot.h
 ///
+/// \brief Creates (maybe) a QCustomPlot based on the configuration parameters
 //===----------------------------------------------------------------------===//
 
 #include <WorkerThread.h>
@@ -16,7 +17,7 @@ void WorkerThread::run() {
   while (true) {
     auto Msg = Consumer->consume();
 
-    Consumer->handleMessage(Msg);
+    Consumer->handleMessage(Msg.get());
 
     t2 = std::chrono::high_resolution_clock::now();
     std::chrono::duration<int64_t, std::nano> elapsed = t2 - t1;
@@ -25,22 +26,10 @@ void WorkerThread::run() {
     /// that plots can be updated.
     if (elapsed.count() >= 1000000000LL) {
 
-      mutex.lock();
-      Consumer->mHistogramPlot = Consumer->mHistogram;
-      Consumer->mHistogramTofPlot = Consumer->mHistogramTof;
-      Consumer->mPixelIDsPlot = Consumer->mPixelIDs;
-      Consumer->mTOFsPlot = Consumer->mTOFs;
-      mutex.unlock();
-
       int ElapsedCountMS = elapsed.count()/1000000;
       emit resultReady(ElapsedCountMS);
 
-      std::fill(Consumer->mHistogram.begin(), Consumer->mHistogram.end(), 0);
-      std::fill(Consumer->mHistogramTof.begin(), Consumer->mHistogramTof.end(), 0);
-      Consumer->mPixelIDs.clear();
-      Consumer->mTOFs.clear();
       t1 = std::chrono::high_resolution_clock::now();
     }
-    delete Msg;
   }
 }

--- a/src/daqlite/WorkerThread.cpp
+++ b/src/daqlite/WorkerThread.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2022-2024 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file CustomAMOR2DTOFPlot.h

--- a/src/daqlite/WorkerThread.h
+++ b/src/daqlite/WorkerThread.h
@@ -28,11 +28,17 @@ public:
     Consumer = std::make_unique<ESSConsumer>(Config, KafkaCfg.CfgParms);
   };
 
+  ~WorkerThread() {
+    this->terminate();
+    this->wait();
+    this->exit();
+  }
+
   /// \brief thread main loop
   void run() override;
 
   /// \brief Getter for the consumer
-  ESSConsumer& getConsumer() {
+  ESSConsumer &getConsumer() {
     if (!Consumer) {
       throw std::runtime_error("Consumer is not initialized");
     }

--- a/src/daqlite/WorkerThread.h
+++ b/src/daqlite/WorkerThread.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 - 2022 European Spallation Source, ERIC. See LICENSE file
+// Copyright (C) 2020 - 2024 European Spallation Source, ERIC. See LICENSE file
 //===----------------------------------------------------------------------===//
 ///
 /// \file WorkerThread.h

--- a/src/daqlite/WorkerThread.h
+++ b/src/daqlite/WorkerThread.h
@@ -36,10 +36,6 @@ public:
   /// \brief Getter for the consumer
   ESSConsumer *consumer() { return Consumer; }
 
-  /// \brief protects vectors<uint32_t> used for histograms
-  /// shared bewteen workerthread and consumer.
-  QMutex mutex;
-
 signals:
   /// \brief this signal is 'emitted' when there is new data to be plotted
   /// this is done periodically (approximately once every second)

--- a/src/daqlite/WorkerThread.h
+++ b/src/daqlite/WorkerThread.h
@@ -6,8 +6,8 @@
 /// \brief main consumer loop for Daquiri Light (daqlite)
 /// The worker thread continuously calls ESSConsumer::consume() and
 /// ESSConsumer::handleMessage() to histogram the pixelids. Once every second
-/// the histogram is copied and the plotting thread (qt main thread?) is
-/// notified.
+/// the plotting thread (qt main thread?) is
+/// notified to update and plot new data.
 //===----------------------------------------------------------------------===//
 
 #pragma once


### PR DESCRIPTION
Some refactor how plots are updated:

- New Thread-safe vector introduced to control data access in consumer.
- Plots can directly access to consumer storage members. (not ideal, observable pattern would be better)
- Consumer updates internal storage members in a locked state (no half readouts)
- Histogram plot, without 2nd binning