### PR TITLE
ECDC-4555: Update daqlite to Qt6 - crash fix

### DIFF
--- a/src/daqlite/Configuration.cpp
+++ b/src/daqlite/Configuration.cpp
@@ -196,9 +196,14 @@ template <typename T>
 T Configuration::getVal(const std::string &Group, const std::string &Option, T Default,
                         bool Throw) {
   T ConfigVal;
-  try {
+
+  // Check if the option is present
+  if (mJsonObj.contains(Group) && mJsonObj[Group].contains(Option)) {
     ConfigVal = mJsonObj[Group][Option];
-  } catch (nlohmann::json::exception &e) {
+  }
+
+  // ... inform, if it is missing
+  else {
     fmt::print("Missing [{}][{}] configuration\n", Group, Option);
     if (Throw) {
       throw std::runtime_error("Daqlite config error");
@@ -207,5 +212,6 @@ T Configuration::getVal(const std::string &Group, const std::string &Option, T D
       return Default;
     }
   }
+
   return ConfigVal;
 }

--- a/src/daqlite/CustomTofPlot.cpp
+++ b/src/daqlite/CustomTofPlot.cpp
@@ -144,7 +144,8 @@ void CustomTofPlot::showPointToolTip(QMouseEvent *event) {
   int xCoordTofValue = int((x + xCoordStep / 2) / xCoordStep) * xCoordStep;
 
   // Get the count value from the data store
-  double count = mGraph->data()->at(xCoordDataIndex)->mainValue();
+  const bool empty = mGraph->data()->isEmpty();
+  double count = (empty) ? 0 : mGraph->data()->at(xCoordDataIndex)->mainValue();
 
   setToolTip(QString("Tof: %1 Count: %2").arg(xCoordTofValue).arg(count));
 }

--- a/src/daqlite/HistogramPlot.cpp
+++ b/src/daqlite/HistogramPlot.cpp
@@ -176,7 +176,8 @@ void HistogramPlot::showPointToolTip(QMouseEvent *event) {
   int xCoordTofValue = int((x + xCoordStep / 2) / xCoordStep) * xCoordStep;
 
   // Get the count value from the data store
-  double count = mGraph->data()->at(xCoordDataIndex)->mainValue();
+  const bool empty = mGraph->data()->isEmpty();
+  double count = (empty) ? 0 : mGraph->data()->at(xCoordDataIndex)->mainValue();
 
   setToolTip(QString("Tof: %1 Value: %2").arg(xCoordTofValue).arg(count));
 }


### PR DESCRIPTION
- Adding check for empty graph data